### PR TITLE
Spark Streaming을 통한 특정 Zone 동시접속자 계산 예제 추가

### DIFF
--- a/src/main/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZone.scala
+++ b/src/main/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZone.scala
@@ -1,0 +1,40 @@
+package com.leeyh0216.spark.example.application
+
+import java.util.concurrent.TimeUnit
+
+import com.leeyh0216.spark.example.log.ZoneInOutLog
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
+import org.apache.spark.sql.functions._
+
+class ConcurrentUsersInZone(spark: SparkSession) {
+  implicit val sqlContext = spark.sqlContext
+
+  def preProcess(streamDF: DataFrame): DataFrame = {
+    streamDF
+      //String 타입의 eventTime을 TimeStamp 타입으로 변경
+      .withColumn("eventTime", to_timestamp(col("eventTime"), "yyyy-MM-dd HH:mm:ss"))
+      //1인 경우 진입이므로 +1, 이외의 경우 퇴장으로 간주하고 -1
+      .withColumn("inOutDelta", when(col("eventType") === lit(1), lit(1)).otherwise(lit(-1)))
+  }
+
+  def process(streamDF: DataFrame): StreamingQuery = {
+    streamDF
+      //마지막 Microbatch의 Max(Event Time) - 10초 까지의 데이터를 Watermark
+      .withWatermark("eventTime", "10 seconds")
+      //1분 단위로 Windowing, Zone으로도 Grouping
+      .groupBy(window(col("eventTime"), "1 minutes").as("window"), col("zone"))
+      //1분 간의 In/Out Delta 합
+      .agg(sum(col("inOutDelta")).as("inOutDelta"))
+      //메모리에 결과를 Flush
+      .writeStream.format("console")
+      .outputMode(OutputMode.Update())
+      .queryName("ConcurrentUsersInZone")
+      .option("truncate", "false")
+      //Watermark 작동 이후에만 결과를 갱신한다.
+      //1초마다 반복적으로 Repeated update trigger가 동작하여 계산하도록 합니다.
+      .trigger(Trigger.ProcessingTime(10, TimeUnit.SECONDS))
+      .start()
+  }
+}

--- a/src/main/scala/com/leeyh0216/spark/example/log/ZoneInOutLog.scala
+++ b/src/main/scala/com/leeyh0216/spark/example/log/ZoneInOutLog.scala
@@ -1,0 +1,11 @@
+package com.leeyh0216.spark.example.log
+
+/**
+  * Zone 진입/퇴장 로그 정의
+  *
+  * @param eventType 1: 진입, 2: 퇴장
+  * @param eventTime Event time, Format: yyyy-MM-dd HH:mm:ss
+  * @param zone      Zone 이름
+  * @param character 캐릭터 UID
+  */
+case class ZoneInOutLog(eventType: Int, eventTime: String, zone: String, character: Int)

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.logger.org.apache.spark.sql.execution.streaming.MicroBatchExecution=INFO, console

--- a/src/test/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZoneTest.scala
+++ b/src/test/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZoneTest.scala
@@ -1,0 +1,71 @@
+package com.leeyh0216.spark.example.application
+
+import com.leeyh0216.spark.example.application.ConcurrentUsersInZone
+import com.leeyh0216.spark.example.log.ZoneInOutLog
+import org.apache.spark.sql
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.junit.{Assert, Test}
+
+class ConcurrentUsersInZoneTest {
+  val spark = new sql.SparkSession.Builder().master("local").appName("ConcurrentUsersInZone").config("spark.driver.host", "localhost").getOrCreate()
+
+  import spark.implicits._
+
+  implicit val sqlContext = spark.sqlContext
+
+  val memoryStream = MemoryStream[ZoneInOutLog]
+
+  val app = new ConcurrentUsersInZone(spark)
+
+  @Test
+  def testPreProcess(): Unit = {
+    val df = Seq(
+      ZoneInOutLog(1, "2019-06-29 13:00:00", "A", 1),
+      ZoneInOutLog(2, "2019-06-29 14:00:00", "A", 1)
+    ).toDF()
+
+    val answer = Seq(
+      (1, "2019-06-29 13:00:00", "A", 1, 1),
+      (2, "2019-06-29 14:00:00", "A", 1, -1)
+    ).toDF("eventType", "eventTime", "zone", "character", "inOutDelta")
+
+    val expected = app.preProcess(df).select("eventType", "eventTime", "zone", "character", "inOutDelta")
+
+    Assert.assertEquals(0, answer.except(expected).count())
+    Assert.assertEquals(0, expected.except(answer).count())
+  }
+
+  @Test
+  def testProcess(): Unit = {
+    val outputStream = app.process(app.preProcess(memoryStream.toDF()))
+
+    memoryStream.addData(
+      ZoneInOutLog(1, "2019-06-29 13:00:00", "A", 1),
+      ZoneInOutLog(2, "2019-06-29 13:00:20", "A", 1),
+      ZoneInOutLog(1, "2019-06-29 13:00:20", "A", 2),
+      ZoneInOutLog(1, "2019-06-29 13:00:45", "A", 1)
+    )
+    outputStream.processAllAvailable()
+    //첫번째 결과 Watermark 적용이 안되기 때문에 빈 테이블이 출력됨
+    Assert.assertEquals(0, spark.table("ConcurrentUsersInZone").count())
+
+    memoryStream.addData(
+      ZoneInOutLog(2, "2019-06-29 13:00:55", "A", 2),
+      ZoneInOutLog(2, "2019-06-29 13:01:11", "A", 1)
+    )
+    val answer2 = Seq(
+      ("A", "2019-06-29 13:00:00", "2019-06-29 13:01:00", 1)
+    ).toDF("zone", "start", "end", "inOutDelta")
+      .withColumn("start", to_timestamp(col("start"), "yyyy-MM-dd HH:mm:ss"))
+      .withColumn("end", to_timestamp(col("end"), "yyyy-MM-dd HH:mm:ss"))
+    outputStream.processAllAvailable()
+
+    val expected2 = spark.table("ConcurrentUsersInZone").select("zone", "window.start", "window.end", "inOutDelta")
+    //두번째 결과
+    //2번째 Stream 중 Event Time 이 가장 큰 2019-06-29 13:01:11 기준으로 Watermark 생성(2019-06-29 13:01:01)
+    //2번째 Stream을 포함한 이전 Stream에서 Event Time이 13:01:01보다 작은 Window들이 계산됨
+    Assert.assertEquals(0, answer2.except(expected2).count())
+
+  }
+}

--- a/src/test/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZoneTest.scala
+++ b/src/test/scala/com/leeyh0216/spark/example/application/ConcurrentUsersInZoneTest.scala
@@ -1,10 +1,10 @@
 package com.leeyh0216.spark.example.application
 
-import com.leeyh0216.spark.example.application.ConcurrentUsersInZone
 import com.leeyh0216.spark.example.log.ZoneInOutLog
 import org.apache.spark.sql
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.streaming.OutputMode
 import org.junit.{Assert, Test}
 
 class ConcurrentUsersInZoneTest {
@@ -37,7 +37,7 @@ class ConcurrentUsersInZoneTest {
   }
 
   @Test
-  def testProcess(): Unit = {
+  def testProcessWithAppendMode(): Unit = {
     val outputStream = app.process(app.preProcess(memoryStream.toDF()))
 
     memoryStream.addData(
@@ -66,6 +66,44 @@ class ConcurrentUsersInZoneTest {
     //2번째 Stream 중 Event Time 이 가장 큰 2019-06-29 13:01:11 기준으로 Watermark 생성(2019-06-29 13:01:01)
     //2번째 Stream을 포함한 이전 Stream에서 Event Time이 13:01:01보다 작은 Window들이 계산됨
     Assert.assertEquals(0, answer2.except(expected2).count())
+    outputStream.stop()
+  }
 
+  @Test
+  def testProcessWithUpdateMode(): Unit = {
+    //Output Mode를 Update로 적용
+    val outputStream = app.process(app.preProcess(memoryStream.toDF()), outputMode = OutputMode.Update())
+
+    memoryStream.addData(
+      ZoneInOutLog(1, "2019-06-29 13:00:00", "A", 1),
+      ZoneInOutLog(2, "2019-06-29 13:00:20", "A", 1),
+      ZoneInOutLog(1, "2019-06-29 13:00:20", "A", 2),
+      ZoneInOutLog(1, "2019-06-29 13:00:45", "A", 1)
+    )
+    outputStream.processAllAvailable()
+    //Watermark가 적용되더라도 Update Mode이기 떄문에 연산 결과가 존재함
+    val answer1 = Seq(
+      ("A", "2019-06-29 13:00:00", "2019-06-29 13:01:00", 2)
+    ).toDF("zone", "start", "end", "inOutDelta")
+      .withColumn("start", to_timestamp(col("start"), "yyyy-MM-dd HH:mm:ss"))
+      .withColumn("end", to_timestamp(col("end"), "yyyy-MM-dd HH:mm:ss"))
+    val expected1 = spark.table("ConcurrentUsersInZone").select("zone", "window.start", "window.end", "inOutDelta")
+    Assert.assertEquals(0, answer1.except(expected1).count())
+
+    memoryStream.addData(
+      ZoneInOutLog(2, "2019-06-29 13:00:55", "A", 2),
+      ZoneInOutLog(2, "2019-06-29 13:01:11", "A", 1)
+    )
+    val answer2 = Seq(
+      ("A", "2019-06-29 13:00:00", "2019-06-29 13:01:00", 1),
+      ("A", "2019-06-29 13:01:00", "2019-06-29 13:02:00", -1)
+    ).toDF("zone", "start", "end", "inOutDelta")
+      .withColumn("start", to_timestamp(col("start"), "yyyy-MM-dd HH:mm:ss"))
+      .withColumn("end", to_timestamp(col("end"), "yyyy-MM-dd HH:mm:ss"))
+    outputStream.processAllAvailable()
+
+    val expected2 = spark.table("ConcurrentUsersInZone").select("zone", "window.start", "window.end", "inOutDelta")
+    Assert.assertEquals(0, answer2.except(expected2).count())
+    outputStream.stop()
   }
 }


### PR DESCRIPTION
- 로그 정의 추가(ZoneInOutLog)
- 어플리케이션 추가(ConcurrentUsersInZone)
- 테스트 추가(ConcurrentUsersInZoneTest)